### PR TITLE
Cache wiki page data

### DIFF
--- a/lib/names.js
+++ b/lib/names.js
@@ -1,29 +1,43 @@
 export default (services) => () => {
   let R = services.R;
-  let getNames = services.axios.get('https://en.wikipedia.org/wiki/List_of_Intel_codenames')
-    .then(function (res) {
+  // request the page from wikipedia that has these names
+  return services.axios.get('https://en.wikipedia.org/wiki/List_of_Intel_codenames')
+  // scrape the names from the html returned by wikipedia
+    .then(res => {
       let html = res.data;
-      // TODO: load backup html here
       const dom = new services.jsdom(html);
       const tds = Array.from(dom.window.document.querySelectorAll('.wikitable.sortable tr > td:first-child'));
       return tds.map(td => td.textContent);
-    });
-  let toKebabCase = R.pipe(
-    str => str.trim(),
-    str => str.toLowerCase(str),
-    str => str.replace(/ /g, '-')
-  );
-  let getName = () => getNames
+    })
+    // return functions to allow access to these names
     .then(names => {
-      let name = names[Math.floor(Math.random()*names.length)];
+      /**
+       * Convert work to kebab case
+       * @param {string} App Name
+       * @returns {string} app-name
+       */
+      let toKebabCase = R.pipe(
+        str => str.trim(),
+        str => str.toLowerCase(str),
+        str => str.replace(/ /g, '-')
+      );
+
+      /**
+       * Get a random intel code name
+       * @return {object} { name: 'App Name', kebabCase: 'app-name'
+       */
+      let getName = () => {
+        let name =  names[Math.floor(Math.random()*names.length)];
+        return {
+          name: name,
+          kebabCase: toKebabCase(name)
+        };
+      };
+
       return {
-        name: name,
-        kebabCase: toKebabCase(name)
+        getName: getName,
+        toKebabCase : toKebabCase
       };
     });
-  return {
-    getName: getName,
-    toKebabCase : toKebabCase
-  };
 };
 

--- a/lib/shell.js
+++ b/lib/shell.js
@@ -10,30 +10,25 @@ export default () => {
     jsdom: jsdom.JSDOM,
     R:R
   };
-  let NamesAPI = createNames(services)();
 
   var app = express();
   app.use(express.static('front_end/public'));
 
-  app.get('/name', function (req, res) {
-    NamesAPI.getName()
-      .then(name => {
+  // createName returns a promise because it has an async setup
+  return createNames(services)()
+    .then(NamesAPI => {
+      app.get('/name', function (req, res) {
+        let name =   NamesAPI.getName();
         res.send(name.name);
       });
-  });
-  app.get('/all', function (req, res) {
-    NamesAPI.getName()
-      .then(x => {
-        res.send(x);
+      app.get('/all', function (req, res) {
+        res.send(NamesAPI.getName());
       });
-  });
-  app.get('/kebab', function (req, res) {
-    NamesAPI.getName()
-      .then(name => {
+      app.get('/kebab', function (req, res) {
+        let name =   NamesAPI.getName();
         res.send(name.kebabCase);
       });
-  });
-
-  var server = app.listen(process.env.PORT || 3000);
-  return server;
+      var server = app.listen(process.env.PORT || 3000);
+      return server;
+    });
 };

--- a/test/names.test.js
+++ b/test/names.test.js
@@ -14,28 +14,36 @@ const realServices = {
   R:R
 };
 describe('Names Module', function () {
-  let realNamesAPI = createNames(realServices)();
+  //let realNamesAPI = createNames(realServices)();
+  var realNamesAPI;
+  beforeEach(function() {
+    realNamesAPI = createNames(realServices)();
+  });
   it('kebabCase swaps space for dash', () => {
-    let name = realNamesAPI.toKebabCase('TEST test');
-    expect(name).to.be.an('string');
-    expect(/-/g.test(name)).to.equal(true);
+    return realNamesAPI.then(function (api) {
+      let name = api.toKebabCase('TEST test');
+      expect(name).to.be.an('string');
+      expect(/-/g.test(name)).to.equal(true);
+    });
   });
   it('kebabCase trims start and end spaces', () => {
-    let name = realNamesAPI.toKebabCase('  TEST test  ');
-    expect(name).to.be.an('string');
-    expect(name[0] !== '-').to.equal(true);
-    expect(name[name.length] !== '-').to.equal(true);
+    return realNamesAPI.then(function (api) {
+      let name = api.toKebabCase('  TEST test  ');
+      expect(name).to.be.an('string');
+      expect(name[0] !== '-').to.equal(true);
+      expect(name[name.length] !== '-').to.equal(true);
+    });
   });
-  it('createGetName returns a function', () => {
-    expect(realNamesAPI.getName).to.be.an('function');
+  it('createGetName returns a promise', () => {
+    expect(realNamesAPI).to.be.an('promise');
   });
   it('getName returnes a names', () => {
-    return realNamesAPI.getName()
-      .then(x => {
-        expect(x).to.be.an('object');
-        expect(x).to.have.property('name');
-        expect(x).to.have.property('kebabCase');
-      });
+    return realNamesAPI.then(function (api) {
+      let names = api.getName();
+      expect(names).to.be.an('object');
+      expect(names).to.have.property('name');
+      expect(names).to.have.property('kebabCase');
+    });
   });
 });
 

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -7,51 +7,72 @@ import createServer from '../lib/shell';
 
 describe('Server Module', function () {
   this.timeout(5000);  // extend timeout to allow for network latency
-  let server;
+  let serverPromise;
   beforeEach(function () {
-    server = createServer();
-  });
-  afterEach(function () {
-    server.close();
+    serverPromise = createServer();
   });
   it('root returns 200', () => {
-    return supertest(server)
-      .get('/')
-      .expect(200);
+    return serverPromise.then(server => {
+      return supertest(server)
+        .get('/')
+        .expect(200)
+        .then(test => {
+          server.close();
+          return test;
+        });
+    });
   });
   it('/name returns a name', () => {
-    return supertest(server)
-      .get('/name')
-      .expect(200)
-      .then(res => {
-        let name = res.text;
-        expect(name).to.be.a('string');
-        expect(/{/g.test(name)).to.equal(false);
-        expect(name.length > 2).to.equal(true);
-      });
+    return serverPromise.then(server => {
+      return supertest(server)
+        .get('/name')
+        .expect(200)
+        .then(res => {
+          let name = res.text;
+          expect(name).to.be.a('string');
+          expect(/{/g.test(name)).to.equal(false);
+          expect(name.length > 2).to.equal(true);
+        })
+        .then(test => {
+          server.close();
+          return test;
+        });
+    });
   });
 
   it('/kebab return a kebab', () => {
-    return supertest(server)
-      .get('/kebab')
-      .expect(200)
-      .then(res => {
-        let name = res.text;
-        expect(name).to.be.a('string');
-        expect(/{/g.test(name)).to.equal(false); // make sure it just a name and not js object
-        expect(name.length > 2).to.equal(true);
-      });
+    return serverPromise.then(server => {
+      return supertest(server)
+        .get('/kebab')
+        .expect(200)
+        .then(res => {
+          let name = res.text;
+          expect(name).to.be.a('string');
+          expect(/{/g.test(name)).to.equal(false); // make sure it just a name and not js object
+          expect(name.length > 2).to.equal(true);
+        })
+        .then(test => {
+          server.close();
+          return test;
+        });
+    });
   });
   it('/all returns json', () => {
-    return supertest(server)
-      .get('/all')
-      .expect(200)
-      .then(res => {
-        let x = JSON.parse(res.text);
-        expect(x).to.be.an('object');
-        expect(x).to.have.property('name');
-        expect(x).to.have.property('kebabCase');
-      });
+    return serverPromise.then(server => {
+      return supertest(server)
+        .get('/all')
+        .expect(200)
+        .then(res => {
+          let x = JSON.parse(res.text);
+          expect(x).to.be.an('object');
+          expect(x).to.have.property('name');
+          expect(x).to.have.property('kebabCase');
+        })
+        .then(test => {
+          server.close();
+          return test;
+        });
+    });
   });
 });
 


### PR DESCRIPTION
In reference to issue #28 :

Cached the Wikipedia page by loading it into memory. Now when the `names.js` API is created it returns a promise of for the API vs the actual API. This change snowballed into quite a few additional updates for things that require this API which is everything including tests.  